### PR TITLE
feat: implement Pong core loop

### DIFF
--- a/src/games/pong/__tests__/pong_core.test.ts
+++ b/src/games/pong/__tests__/pong_core.test.ts
@@ -1,9 +1,31 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createPongState, VIEWPORT_W, VIEWPORT_H } from '../state';
+import { render } from '../render';
 
-import { describe, it, expect } from 'vitest';
+function createMockCtx(): CanvasRenderingContext2D {
+  return {
+    clearRect: vi.fn(),
+    beginPath: vi.fn(),
+    moveTo: vi.fn(),
+    lineTo: vi.fn(),
+    stroke: vi.fn(),
+    setLineDash: vi.fn(),
+    strokeStyle: '',
+  } as unknown as CanvasRenderingContext2D;
+}
 
 describe('pong_core', () => {
   it('createPongState returns default scores=0,0', () => {
-    // to be implemented by agent
-    expect(true).toBe(true);
+    const state = createPongState();
+    expect(state.scores).toEqual([0, 0]);
+  });
+
+  it('render draws midline', () => {
+    const ctx = createMockCtx();
+    render(ctx, createPongState());
+    const mid = VIEWPORT_W / 2;
+    expect(ctx.moveTo).toHaveBeenCalledWith(mid, 0);
+    expect(ctx.lineTo).toHaveBeenCalledWith(mid, VIEWPORT_H);
+    expect(ctx.stroke).toHaveBeenCalled();
   });
 });

--- a/src/games/pong/render.ts
+++ b/src/games/pong/render.ts
@@ -1,0 +1,21 @@
+import { VIEWPORT_W, VIEWPORT_H, PongState } from './state';
+
+export function render(
+  ctx: CanvasRenderingContext2D,
+  _state: PongState,
+): void {
+  ctx.clearRect(0, 0, VIEWPORT_W, VIEWPORT_H);
+
+  const midX = VIEWPORT_W / 2;
+  ctx.strokeStyle = 'white';
+  if (ctx.setLineDash) {
+    ctx.setLineDash([5, 5]);
+  }
+  ctx.beginPath();
+  ctx.moveTo(midX, 0);
+  ctx.lineTo(midX, VIEWPORT_H);
+  ctx.stroke();
+  if (ctx.setLineDash) {
+    ctx.setLineDash([]);
+  }
+}

--- a/src/games/pong/state.ts
+++ b/src/games/pong/state.ts
@@ -1,0 +1,12 @@
+export const VIEWPORT_W = 480;
+export const VIEWPORT_H = 320;
+
+export interface PongState {
+  scores: [number, number];
+}
+
+export function createPongState(): PongState {
+  return {
+    scores: [0, 0],
+  };
+}


### PR DESCRIPTION
## Summary
- add Pong state creator with viewport constants
- render Pong midline on canvas
- test state creation and midline rendering

## Testing
- `npm run validate:tickets` *(fails: Unknown file extension ".ts" for scripts/validate_tickets.ts)*
- `npm run typecheck`
- `npm run test:agent`


------
https://chatgpt.com/codex/tasks/task_e_68ba2018146c832d8566c3c3597242c0