### PR TITLE
feat(pong): add core state and rendering

### DIFF
--- a/src/games/pong/__tests__/pong_core.test.ts
+++ b/src/games/pong/__tests__/pong_core.test.ts
@@ -1,9 +1,43 @@
 
 import { describe, it, expect } from 'vitest';
+import { createPongState, VIEWPORT_W, VIEWPORT_H } from '../state';
+import { render } from '../render';
+
+// Minimal mock canvas context that records drawing operations. This allows
+// us to assert that the renderer attempts to draw the midline.
+class MockCtx {
+  canvas = { width: VIEWPORT_W, height: VIEWPORT_H } as HTMLCanvasElement;
+  ops: { name: string; args: any[] }[] = [];
+  fillStyle = '';
+  strokeStyle = '';
+
+  setLineDash(args: number[]) { this.ops.push({ name: 'setLineDash', args }); }
+  beginPath() { this.ops.push({ name: 'beginPath', args: [] }); }
+  moveTo(x: number, y: number) { this.ops.push({ name: 'moveTo', args: [x, y] }); }
+  lineTo(x: number, y: number) { this.ops.push({ name: 'lineTo', args: [x, y] }); }
+  stroke() { this.ops.push({ name: 'stroke', args: [] }); }
+  fillRect(x:number,y:number,w:number,h:number){ this.ops.push({name:'fillRect', args:[x,y,w,h]}); }
+  clearRect(x:number,y:number,w:number,h:number){ this.ops.push({name:'clearRect', args:[x,y,w,h]}); }
+}
 
 describe('pong_core', () => {
   it('createPongState returns default scores=0,0', () => {
-    // to be implemented by agent
-    expect(true).toBe(true);
+    const state = createPongState();
+    expect(state.score).toEqual([0, 0]);
+  });
+
+  it('render draws midline', () => {
+    const ctx = new MockCtx();
+    const state = createPongState();
+    render(ctx as unknown as CanvasRenderingContext2D, state);
+
+    const moveIdx = ctx.ops.findIndex(
+      (op) => op.name === 'moveTo' && op.args[0] === VIEWPORT_W / 2 && op.args[1] === 0,
+    );
+    const lineIdx = ctx.ops.findIndex(
+      (op) => op.name === 'lineTo' && op.args[0] === VIEWPORT_W / 2 && op.args[1] === VIEWPORT_H,
+    );
+    expect(moveIdx).toBeGreaterThan(-1);
+    expect(lineIdx).toBeGreaterThan(moveIdx);
   });
 });

--- a/src/games/pong/render.ts
+++ b/src/games/pong/render.ts
@@ -1,0 +1,30 @@
+// Pong rendering logic using Canvas2D
+import { PongState, VIEWPORT_W, VIEWPORT_H } from './state';
+
+/**
+ * Render the current Pong state to the provided CanvasRenderingContext2D.
+ * For the core ticket we simply clear the screen and draw the midline to
+ * establish the playfield.  Future tickets will extend this renderer to draw
+ * paddles, ball, and scores.
+ */
+export function render(ctx: CanvasRenderingContext2D, state: PongState) {
+  // ensure canvas matches expected viewport
+  ctx.canvas.width = VIEWPORT_W;
+  ctx.canvas.height = VIEWPORT_H;
+
+  // clear background
+  ctx.fillStyle = '#000';
+  ctx.fillRect(0, 0, VIEWPORT_W, VIEWPORT_H);
+
+  // draw midline dashed
+  ctx.strokeStyle = '#fff';
+  ctx.setLineDash([4, 4]);
+  ctx.beginPath();
+  ctx.moveTo(VIEWPORT_W / 2, 0);
+  ctx.lineTo(VIEWPORT_W / 2, VIEWPORT_H);
+  ctx.stroke();
+
+  // state is currently unused but retained for future features
+  void state;
+}
+

--- a/src/games/pong/state.ts
+++ b/src/games/pong/state.ts
@@ -1,0 +1,65 @@
+// Pong game state and constants
+
+// viewport size constants – exported for use by renderer and tests
+export const VIEWPORT_W = 480;
+export const VIEWPORT_H = 320;
+
+// Basic types used for the Pong game.  These are intentionally minimal and
+// will be expanded by later tickets as the game logic grows.
+export interface Paddle {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface Ball {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  radius: number;
+}
+
+export interface PongState {
+  leftPaddle: Paddle;
+  rightPaddle: Paddle;
+  ball: Ball;
+  /** player scores: [left, right] */
+  score: [number, number];
+}
+
+/**
+ * createPongState
+ *
+ * Returns the default state for a Pong match.  Scores start at 0 for both
+ * players; paddles and ball are positioned in their typical starting spots.
+ */
+export function createPongState(): PongState {
+  const paddleW = 10;
+  const paddleH = 60;
+
+  return {
+    leftPaddle: {
+      x: 10,
+      y: (VIEWPORT_H - paddleH) / 2,
+      width: paddleW,
+      height: paddleH,
+    },
+    rightPaddle: {
+      x: VIEWPORT_W - 10 - paddleW,
+      y: (VIEWPORT_H - paddleH) / 2,
+      width: paddleW,
+      height: paddleH,
+    },
+    ball: {
+      x: VIEWPORT_W / 2,
+      y: VIEWPORT_H / 2,
+      vx: 0,
+      vy: 0,
+      radius: 5,
+    },
+    score: [0, 0],
+  };
+}
+


### PR DESCRIPTION
## Summary
- set up initial Pong state with scores, paddles, and ball
- draw a dashed midline for the Pong playfield
- test default state and midline rendering

## Testing
- `npm run validate:tickets` *(fails: ERR_REQUIRE_CYCLE_MODULE)*
- `npm run typecheck`
- `npm run test:agent`


------
https://chatgpt.com/codex/tasks/task_e_68ba2018146c832d8566c3c3597242c0